### PR TITLE
FIX OIDC token selection for sourcing "member_of" or "roles" claim

### DIFF
--- a/app/models/oic_session.rb
+++ b/app/models/oic_session.rb
@@ -136,7 +136,7 @@ class OicSession < ActiveRecord::Base
     if user["resource_access"].present? && user["resource_access"][client_config['client_id']].present?
       kc_is_in_role = user["resource_access"][client_config['client_id']]["roles"].include?(role)
     end
-    return true if kc_is_in_role 
+    return true if kc_is_in_role
   end
 
   def authorized?
@@ -152,7 +152,7 @@ class OicSession < ActiveRecord::Base
 
     if client_config['group'].present?
        return true if user["member_of"].present? && user["member_of"].include?(client_config['group'])
-       return true if user["roles"].present? && user["roles"].include?(client_config['group']) || user["roles"].include?(client_config['admin_group']) 
+       return true if user["roles"].present? && user["roles"].include?(client_config['group']) || user["roles"].include?(client_config['admin_group'])
     end
 
     return false
@@ -163,21 +163,22 @@ class OicSession < ActiveRecord::Base
       if user["member_of"].present?
         return true if user["member_of"].include?(client_config['admin_group'])
       end
-      if user["roles"].present? 
+      if user["roles"].present?
         return true if user["roles"].include?(client_config['admin_group'])
       end
       # keycloak way...
       return true if check_keycloak_role client_config['admin_group']
     end
-    
+
     return false
   end
 
   def user
-    if access_token? # keycloak way...
-      @user = JSON::parse(Base64::decode64(access_token.split('.')[1]))
+    token = access_token.present? ? JSON.parse(Base64.decode64(access_token.split('.')[1])) : {}
+    if token["member_of"].present?
+      @user = token
     else
-      @user = JSON::parse(Base64::decode64(id_token.split('.')[1]))
+      @user = JSON.parse(Base64.decode64(id_token.split('.')[1]))
     end
     return @user
   end
@@ -235,7 +236,7 @@ class OicSession < ActiveRecord::Base
       'session_state' => session_state,
       'post_logout_redirect_uri' => "#{host_name}/oic/local_logout",
     }
-    if id_token.present? 
+    if id_token.present?
       query['id_token_hint'] = id_token
     end
    return query

--- a/app/models/oic_session.rb
+++ b/app/models/oic_session.rb
@@ -174,12 +174,17 @@ class OicSession < ActiveRecord::Base
   end
 
   def user
-    token = access_token.present? ? JSON.parse(Base64.decode64(access_token.split('.')[1])) : {}
-    if token["member_of"].present?
-      @user = token
-    else
-      @user = JSON.parse(Base64.decode64(id_token.split('.')[1]))
+    # user info from access_token, the keycloak way...
+    if access_token?
+      token = JSON::parse(Base64::decode64(access_token.split('.')[1]))
+      if token["member_of"].present? || token["roles"].present?
+        @user = token
+        return @user
+      end
     end
+
+    # user info from id_token, the regular way...
+    @user = JSON.parse(Base64.decode64(id_token.split('.')[1]))
     return @user
   end
 


### PR DESCRIPTION
## Problem: "member_of" and "roles" claims in id_token ignored
Since there should also be an access_token, when something other than keycloak is being used, this function results in the id_token being ignored, regardless of whether or not the access_token contains the needed claims or not.
```
  def user
    if access_token? # keycloak way...
      @user = JSON::parse(Base64::decode64(access_token.split('.')[1]))
    else
      @user = JSON::parse(Base64::decode64(id_token.split('.')[1]))
    end
    return @user
  end
```

## Fix: Checking the content of the access_token
checking the content of the access_token like this resolves the problem
```
    if access_token?
      token = JSON::parse(Base64::decode64(access_token.split('.')[1]))
      if token["member_of"].present? || token["roles"].present?
        @user = token
      end
    end
```
if it does not contain the claims, we default to the id_token
```
    # user info from id_token, the regular way...
    @user = JSON.parse(Base64.decode64(id_token.split('.')[1]))
    return @user
  end
```
